### PR TITLE
Use config instead of env

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Darius Matulionis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Or you can simply change the default log channel in the .env
 LOG_CHANNEL=telegram
 ```
 
+Publish config file
+```
+php artisan vendor:publish --provider "Logger\TelegramLoggerServiceProvider"
+```
+
 ## Create bot
 
 For using this package you need to create Telegram bot

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,14 @@
     "monolog/monolog": "^1.23",
     "laravel/framework": "5.6.*|5.7.*"
   },
-  "version":"0.1.1",
+  "version":"0.1.2",
   "minimum-stability": "dev",
-  "prefer-stable": true
+  "prefer-stable": true,
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Logger\\TelegramLoggerServiceProvider"
+      ]
+    }
+  }
 }

--- a/config/telegram-logger.php
+++ b/config/telegram-logger.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    // Telegram logger bot token
+    'token' => env('TELEGRAM_LOGGER_BOT_TOKEN'),
+
+    // Telegram chat id
+    'chat_id' => env('TELEGRAM_LOGGER_CHAT_ID')
+];

--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -51,8 +51,8 @@ class TelegramHandler extends AbstractProcessingHandler
         parent::__construct($level, true);
 
         // define variables for making Telegram request
-        $this->botToken = env('TELEGRAM_LOGGER_BOT_TOKEN');
-        $this->chatId   = env('TELEGRAM_LOGGER_CHAT_ID');
+        $this->botToken = config('telegram-logger.token');
+        $this->chatId   = config('telegram-logger.chat_id');
 
         // define variables for text message
         $this->appName = config('app.name');

--- a/src/TelegramLogger.php
+++ b/src/TelegramLogger.php
@@ -19,7 +19,7 @@ class TelegramLogger
     public function __invoke(array $config)
     {
         return new Logger(
-            env('APP_NAME'),
+            config('app.name'),
             [
                 new TelegramHandler($config['level'])
             ]

--- a/src/TelegramLoggerServiceProvider.php
+++ b/src/TelegramLoggerServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Logger;
+
+use Illuminate\Support\ServiceProvider;
+
+/**
+ * Class TelegramLoggerServiceProvider
+ * @package Logger
+ */
+class TelegramLoggerServiceProvider extends ServiceProvider
+{
+    /**
+     * Register bindings in the container.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../config/telegram-logger.php', 'telegram-logger');
+    }
+
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $this->publishes([__DIR__ . '/../config/telegram-logger.php' => config_path('telegram-logger.php')], 'config');
+    }
+}


### PR DESCRIPTION
Fixed #1 issue. Use config variables instead of env.
Update README. 