### PR TITLE
Description property added to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,7 @@
 {
   "name": "grkamil/laravel-telegram-logging",
+  "description": "Send logs to Telegram chat via Telegram bot",
+  "license": "MIT",
   "autoload": {
     "psr-0" : {
       "Logger\\" : "src"


### PR DESCRIPTION
./composer.json is valid for simple usage with composer but has strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
description : The property description is required