### PR TITLE
Use PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Send logs to Telegram chat via Telegram bot",
   "license": "MIT",
   "autoload": {
-    "psr-0" : {
+    "psr-4" : {
       "Logger\\" : "src"
     }
   },


### PR DESCRIPTION
Hi, latest composer versions show an error while installing the package:

![image](https://user-images.githubusercontent.com/5755685/77295496-20215a00-6cf7-11ea-9a03-74fe28bd5adf.png)

According to [PSR-0 standard](https://www.php-fig.org/psr/psr-0/): 

>  A fully-qualified namespace and class must have the following structure `\<Vendor Name>\(<Namespace>\)*<Class Name>`

Using PSR-4 solves this problem.