### PR TITLE
Add telegram api host to config

### DIFF
--- a/config/telegram-logger.php
+++ b/config/telegram-logger.php
@@ -13,6 +13,9 @@ return [
     // Proxy server
     'proxy' => env('TELEGRAM_LOGGER_PROXY', ''),
 
+    // Telegram API host without trailling slash
+    'api_host' => env('TELEGRAM_LOGGER_API_HOST', 'https://api.telegram.org'),
+
     // Telegram sendMessage options: https://core.telegram.org/bots/api#sendmessage
     'options' => [
         // 'parse_mode' => 'html',

--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -140,7 +140,9 @@ class TelegramHandler extends AbstractProcessingHandler
             config('telegram-logger.options', [])
         ));
 
-        $url = 'https://api.telegram.org/bot' . $this->botToken . '/sendMessage?' . $httpQuery;
+        $host = $this->getConfigValue('api_host');
+
+        $url = $host . '/bot' . $this->botToken . '/sendMessage?' . $httpQuery;
 
         $proxy = $this->getConfigValue('proxy');
 


### PR DESCRIPTION
Hello! I have added the Telegram API host to the config file in this pull request. This change offers two benefits to the user. Firstly, by modifying the API host, the user can employ a reverse proxy to request the Telegram API. Secondly, there are a few messaging apps that share the same API as Telegram, so users can use this package for those apps as well.

Thanks