### PR TITLE
Do not use root facade alias for Log

### DIFF
--- a/src/TelegramHandler.php
+++ b/src/TelegramHandler.php
@@ -3,6 +3,7 @@
 namespace Logger;
 
 use Exception;
+use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\LineFormatter;
@@ -88,7 +89,7 @@ class TelegramHandler extends AbstractProcessingHandler
                 $this->sendMessage($textChunk);
             }
         } catch (Exception $exception) {
-            \Log::channel('single')->error($exception->getMessage());
+            Log::channel('single')->error($exception->getMessage());
         }
     }
 


### PR DESCRIPTION
Root aliases for Facades are optional and can be disabled on app level.