### PR TITLE
Add support for Laravel 13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require": {
         "php": "^7.1.3|^8.0",
         "monolog/monolog": "^1.23|^2.0|^3.2",
-        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0|^11.0|^12.0"
+        "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0 || ^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
## Summary
Updated the `illuminate/support` dependency constraint to include Laravel 13 compatibility.

## Changes
- Extended the `illuminate/support` version constraint to accept `^13.0` releases, allowing this package to be used with Laravel 13

## Details
This change maintains backward compatibility with all previously supported Laravel versions (5.5 through 12.0) while adding support for the upcoming Laravel 13 release.

https://claude.ai/code/session_017AzoCAmfrMVf7PqfDNeqpy